### PR TITLE
make rooms.InitialState invariant

### DIFF
--- a/mautrix/client/api/rooms.py
+++ b/mautrix/client/api/rooms.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, List, Union, Dict, Any, Sequence
 import asyncio
 
 from multidict import CIMultiDict
@@ -18,7 +18,7 @@ from mautrix.types import (JSON, UserID, RoomID, RoomAlias, StateEvent, RoomDire
 from .events import EventMethods
 from .base import BaseClientAPI
 
-InitialState = List[Union[StateEvent, StrippedStateEvent, Dict[str, Any]]]
+InitialState = Sequence[Union[StateEvent, StrippedStateEvent, Dict[str, Any]]]
 
 
 class RoomMethods(EventMethods, BaseClientAPI):


### PR DESCRIPTION
Without this, I get the following error:
```
linkedin_matrix/portal.py:468: error: Argument "initial_state" to "create_room" of "RoomMethods" has incompatible type "List[Dict[str, Collection[str]]]"; expected "Optional[List[Union[StateEvent, StrippedStateEvent, Dict[str, Any]]]]"
linkedin_matrix/portal.py:468: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
linkedin_matrix/portal.py:468: note: Consider using "Sequence" instead, which is covariant
```