### PR TITLE
Add support for message send checkpoints

### DIFF
--- a/mautrix/bridge/config.py
+++ b/mautrix/bridge/config.py
@@ -57,6 +57,7 @@ class BaseBridgeConfig(BaseFileConfig, BaseValidatableConfig, ABC):
         copy("homeserver.verify_ssl")
         copy("homeserver.http_retry_count")
         copy("homeserver.status_endpoint")
+        copy("homeserver.message_send_checkpoint_endpoint")
 
         copy("appservice.address")
         copy("appservice.hostname")

--- a/mautrix/bridge/user.py
+++ b/mautrix/bridge/user.py
@@ -155,6 +155,8 @@ class BaseUser(ABC):
         message_type: MessageType,
         error: Optional[Exception] = None,
     ):
+        if not self.bridge.config["homeserver.message_send_checkpoint_endpoint"]:
+            return
         await MessageSendCheckpoint(
             event_id=event_id,
             room_id=room_id,

--- a/mautrix/util/__init__.py
+++ b/mautrix/util/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["formatter", "logging", "config", "signed_token", "simple_template", "manhole",
            "markdown", "simple_lock", "file_store", "program", "async_db", "db", "opt_prometheus",
-           "color_log", "magic", "bridge_state"]
+           "color_log", "magic", "bridge_state", "message_send_checkpoint"]

--- a/mautrix/util/message_send_checkpoint.py
+++ b/mautrix/util/message_send_checkpoint.py
@@ -37,6 +37,7 @@ class MessageSendCheckpoint(SerializableAttrs):
     event_type: str
     reported_by: MessageSendCheckpointReportedBy
     retry_num: int = 0
+    message_type: Optional[str] = None
     info: Optional[str] = None
 
     async def send(self, log: logging.Logger, endpoint: str, as_token: str):

--- a/mautrix/util/message_send_checkpoint.py
+++ b/mautrix/util/message_send_checkpoint.py
@@ -1,5 +1,7 @@
 from typing import Optional
 from attr import dataclass
+
+from mautrix.types.event.type import EventType
 from mautrix.types.util.serializable import SerializableEnum
 from mautrix.types.util.serializable_attrs import SerializableAttrs
 
@@ -26,12 +28,26 @@ class MessageSendCheckpointReportedBy(SerializableEnum):
 class MessageSendCheckpoint(SerializableAttrs):
     event_id: str
     room_id: str
-    username: str
     step: MessageSendCheckpointStep
-    bridge: str
     timestamp: int
     status: MessageSendCheckpointStatus
     event_type: str
     reported_by: MessageSendCheckpointReportedBy
     retry_num: int = 0
     info: Optional[str] = None
+
+
+CHECKPOINT_TYPES = {
+    EventType.ROOM_REDACTION,
+    EventType.ROOM_MESSAGE,
+    EventType.ROOM_ENCRYPTED,
+    EventType.STICKER,
+    EventType.REACTION,
+    EventType.CALL_INVITE,
+    EventType.CALL_CANDIDATES,
+    EventType.CALL_SELECT_ANSWER,
+    EventType.CALL_ANSWER,
+    EventType.CALL_HANGUP,
+    EventType.CALL_REJECT,
+    EventType.CALL_NEGOTIATE,
+}

--- a/mautrix/util/message_send_checkpoint.py
+++ b/mautrix/util/message_send_checkpoint.py
@@ -43,19 +43,23 @@ class MessageSendCheckpoint(SerializableAttrs):
     async def send(self, log: logging.Logger, endpoint: str, as_token: str):
         try:
             headers = {"Authorization": f"Bearer {as_token}"}
-            async with aiohttp.ClientSession() as sess, \
-                       sess.post(endpoint, json={"checkpoints": [self.serialize()]},
-                                 headers=headers, timeout=ClientTimeout(5)) as resp:
+            async with aiohttp.ClientSession() as sess, sess.post(
+                endpoint,
+                json={"checkpoints": [self.serialize()]},
+                headers=headers,
+                timeout=ClientTimeout(5),
+            ) as resp:
                 if not 200 <= resp.status < 300:
                     text = await resp.text()
                     text = text.replace("\n", "\\n")
-                    log.warning(f"Unexpected status code {resp.status} sending message send"
-                                     f" checkpoints for {self.event_id}: {text}")
+                    log.warning(
+                        f"Unexpected status code {resp.status} sending message send checkpoints"
+                        f" for {self.event_id}: {text}"
+                    )
                 else:
                     log.info(f"Successfully sent message send checkpoints for {self.event_id}")
         except Exception as e:
             log.warning(f"Failed to send message send checkpoints for {self.event_id}: {e}")
-
 
 
 CHECKPOINT_TYPES = {

--- a/mautrix/util/message_send_checkpoint.py
+++ b/mautrix/util/message_send_checkpoint.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from attr import dataclass
+from mautrix.types.util.serializable import SerializableEnum
+from mautrix.types.util.serializable_attrs import SerializableAttrs
+
+
+class MessageSendCheckpointStep(SerializableEnum):
+    CLIENT = "CLIENT"
+    HOMESERVER = "HOMESERVER"
+    BRIDGE = "BRIDGE"
+    REMOTE = "REMOTE"
+
+
+class MessageSendCheckpointStatus(SerializableEnum):
+    SUCCESS = "SUCCESS"
+    WILL_RETRY = "WILL_RETRY"
+    PERM_FAILURE = "PERM_FAILURE"
+
+
+class MessageSendCheckpointReportedBy(SerializableEnum):
+    ASMUX = "ASMUX"
+    BRIDGE = "BRIDGE"
+
+
+@dataclass
+class MessageSendCheckpoint(SerializableAttrs):
+    event_id: str
+    room_id: str
+    username: str
+    step: MessageSendCheckpointStep
+    bridge: str
+    timestamp: int
+    status: MessageSendCheckpointStatus
+    event_type: str
+    reported_by: MessageSendCheckpointReportedBy
+    retry_num: int = 0
+    info: Optional[str] = None


### PR DESCRIPTION
- Added new config `homeserver.message_send_checkpoint_endpoint`
- When a message gets to the bridge, it sends a checkpoint on the configured endpoint.
- Added a `send_remote_checkpoint` to `BaseUser` for bridges to consume.
- Added all of the necessary supporting objects into `mautrix/util/message_send_checkpoint.py`