### PR TITLE
Add configurable connection limit

### DIFF
--- a/mautrix/appservice/appservice.py
+++ b/mautrix/appservice/appservice.py
@@ -63,7 +63,7 @@ class AppService(AppServiceServerMixin):
                  real_user_content_key: Optional[str] = "net.maunium.appservice.puppet",
                  state_store: ASStateStore = None, aiohttp_params: Dict = None,
                  ephemeral_events: bool = False, default_ua: str = HTTPAPI.default_ua,
-                 default_http_retry_count: int = 0) -> None:
+                 default_http_retry_count: int = 0, connection_limit: int = None) -> None:
         super().__init__(ephemeral_events=ephemeral_events)
         self.server = server
         self.domain = domain
@@ -71,6 +71,7 @@ class AppService(AppServiceServerMixin):
         self.verify_ssl = verify_ssl
         self.tls_cert = tls_cert
         self.tls_key = tls_key
+        self.connection_limit = connection_limit or 100
         self.as_token = as_token
         self.hs_token = hs_token
         self.bot_mxid = UserID(f"@{bot_localpart}:{domain}")
@@ -126,10 +127,11 @@ class AppService(AppServiceServerMixin):
 
     async def start(self, host: str = "127.0.0.1", port: int = 8080) -> None:
         await self.state_store.open()
-        connector = None
         self.log.debug(f"Starting appservice web server on {host}:{port}")
         if self.server.startswith("https://") and not self.verify_ssl:
-            connector = aiohttp.TCPConnector(verify_ssl=False)
+            connector = aiohttp.TCPConnector(limit=self.connection_limit, verify_ssl=False)
+        else:
+            connector = aiohttp.TCPConnector(limit=self.connection_limit)
         default_headers = {"User-Agent": self.default_ua}
         self._http_session = aiohttp.ClientSession(loop=self.loop, connector=connector,
                                                    headers=default_headers)

--- a/mautrix/bridge/bridge.py
+++ b/mautrix/bridge/bridge.py
@@ -115,6 +115,7 @@ class Bridge(Program, ABC):
         self.az = AppService(server=self.config["homeserver.address"],
                              domain=self.config["homeserver.domain"],
                              verify_ssl=self.config["homeserver.verify_ssl"],
+                             connection_limit=self.config["homeserver.connection_limit"],
 
                              id=self.config["appservice.id"],
                              as_token=self.config["appservice.as_token"],

--- a/mautrix/bridge/config.py
+++ b/mautrix/bridge/config.py
@@ -56,6 +56,7 @@ class BaseBridgeConfig(BaseFileConfig, BaseValidatableConfig, ABC):
         copy("homeserver.domain")
         copy("homeserver.verify_ssl")
         copy("homeserver.http_retry_count")
+        copy("homeserver.connection_limit")
         copy("homeserver.status_endpoint")
         copy("homeserver.message_send_checkpoint_endpoint")
 


### PR DESCRIPTION
Adds support for a new option `homeserver.connection_limit` which specifies the maximum number of simultaneous HTTP connections to the homeserver.
Defaults to `100`, the same value [TCPConnector](https://docs.aiohttp.org/en/stable/client_reference.html#tcpconnector) uses if no limit is provided.

Example addition to a config file:
```yaml
homeserver:
    ...
    # Maximum number of simultaneous HTTP connections to the homeserver.
    connection_limit: 100
```