### PR TITLE
Add metrics about Matrix API events

### DIFF
--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -59,7 +59,12 @@ class EventMethods(BaseClientAPI):
             request["full_state"] = "true" if full_state else "false"
         if set_presence:
             request["set_presence"] = str(set_presence)
-        return self.api.request(Method.GET, Path.sync, query_params=request, retry_count=0)
+        API_CALLS.labels(method="sync").inc()
+        try:
+            return await self.api.request(Method.GET, Path.sync, query_params=request, retry_count=0)
+        except Error as e:
+            API_CALLS_FAILED.labels(method="sync").inc()
+            raise e
 
     # endregion
     # region 8.3 Getting events for a room

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -63,7 +63,7 @@ class EventMethods(BaseClientAPI):
             request["set_presence"] = str(set_presence)
         method = "sync"
         API_CALLS.labels(method=method).inc()
-        start_time = time.time()
+        start_time = time()
         outcome = "success"
         try:
             return await self.api.request(Method.GET, Path.sync, query_params=request, retry_count=0)

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -21,7 +21,7 @@ API_CALLS = Counter("bridge_matrix_api_calls",
                     "The number of Matrix client API calls made", ("method",))
 API_CALLS_FAILED = Counter("bridge_matrix_api_calls_failed",
                            "The number of Matrix client API calls which failed", ("method",))
-MATRIX_REQUEST_SECONDS = Histogram("matrix_request_seconds",
+MATRIX_REQUEST_SECONDS = Histogram("bridge_matrix_request_seconds",
                                    "Time spent on Matrix client API calls", ("method","outcome",))
 
 class EventMethods(BaseClientAPI):

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -65,9 +65,9 @@ class EventMethods(BaseClientAPI):
         start_time = time.time()
         try:
             return await self.api.request(Method.GET, Path.sync, query_params=request, retry_count=0)
-        except Error as e:
+        except Exception:
             API_CALLS_FAILED.labels(method="sync").inc()
-            raise e
+            raise
         finally:
             API_CALLS_TIME.labels(method="sync").observe(time.time() - start_time)
 

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -22,7 +22,7 @@ API_CALLS = Counter("bridge_matrix_api_calls",
 API_CALLS_FAILED = Counter("bridge_matrix_api_calls_failed",
                            "The number of Matrix client API calls which failed", ("method",))
 API_CALLS_TIME = Histogram("bridge_matrix_api_calls_update",
-                           "Time spent processing Telegram updates", ("method",))
+                           "Time spent on Matrix client API calls", ("method",))
 
 class EventMethods(BaseClientAPI):
     """

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -14,6 +14,7 @@ from mautrix.types import (JSON, UserID, RoomID, EventID, FilterID, SyncToken, P
                            MediaMessageEventContent, PresenceState, EventContent, Membership,
                            ReactionEventContent, RelationType, Obj, Serializable)
 from mautrix.types.event.state import state_event_content_map
+from mautrix.util.opt_prometheus import Counter
 from .base import BaseClientAPI
 
 API_CALLS = Counter("bridge_matrix_api_calls",

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -206,9 +206,9 @@ class EventMethods(BaseClientAPI):
         method = "getMembers"
         API_CALLS.labels(method=method).inc()
         start_time = time.time()
-        content = await self.api.request(Method.GET, Path.rooms[room_id].members,
-                                         query_params=query)
         try:
+            content = await self.api.request(Method.GET, Path.rooms[room_id].members,
+                                            query_params=query)
             try:
                 return [StateEvent.deserialize(event) for event in content["chunk"]]
             except KeyError:
@@ -348,9 +348,9 @@ class EventMethods(BaseClientAPI):
         method = "sendStateEvent"
         API_CALLS.labels(method=method).inc()
         start_time = time.time()
-        resp = await self.api.request(Method.PUT, Path.rooms[room_id].state[event_type][state_key],
-                                      content, **kwargs)
         try:
+            resp = await self.api.request(Method.PUT, Path.rooms[room_id].state[event_type][state_key],
+                                        content, **kwargs)
             try:
                 return resp["event_id"]
             except KeyError:

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -17,9 +17,9 @@ from mautrix.types.event.state import state_event_content_map
 from .base import BaseClientAPI
 
 API_CALLS = Counter("bridge_matrix_api_calls",
-                    "The number of Matrix client API calls made", ("update_type",))
+                    "The number of Matrix client API calls made", ("method",))
 API_CALLS_FAILED = Counter("bridge_matrix_api_calls_failed",
-                    "The number of Matrix client API calls which failed", ("update_type",))
+                    "The number of Matrix client API calls which failed", ("method",))
 
 class EventMethods(BaseClientAPI):
     """

--- a/mautrix/client/api/events.py
+++ b/mautrix/client/api/events.py
@@ -80,6 +80,7 @@ class EventMethods(BaseClientAPI):
         .. _/event/{eventId} API reference:
             https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-event-eventid
         """
+        API_CALLS.labels(method="getEvent").inc()
         content = await self.api.request(Method.GET, Path.rooms[room_id].event[event_id])
         try:
             return Event.deserialize(content)
@@ -105,6 +106,7 @@ class EventMethods(BaseClientAPI):
         .. _GET /state/{eventType}/{stateKey} API reference:
             https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-state-eventtype-statekey
         """
+        API_CALLS.labels(method="getStateEvent").inc()
         content = await self.api.request(Method.GET,
                                          Path.rooms[room_id].state[event_type][state_key])
         try:
@@ -127,6 +129,7 @@ class EventMethods(BaseClientAPI):
         .. _/state API reference:
             https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-state
         """
+        API_CALLS.labels(method="getState").inc()
         content = await self.api.request(Method.GET, Path.rooms[room_id].state)
         try:
             return [StateEvent.deserialize(event) for event in content]
@@ -164,6 +167,7 @@ class EventMethods(BaseClientAPI):
             query["membership"] = membership.value
         if not_membership:
             query["not_membership"] = not_membership.value
+        API_CALLS.labels(method="getMembers").inc()
         content = await self.api.request(Method.GET, Path.rooms[room_id].members,
                                          query_params=query)
         try:
@@ -192,6 +196,7 @@ class EventMethods(BaseClientAPI):
         .. _/members:
             https://matrix.org/docs/spec/client_server/r0.5.0#get-matrix-client-r0-rooms-roomid-members
         """
+        API_CALLS.labels(method="getJoinedMembers").inc()
         content = await self.api.request(Method.GET, Path.rooms[room_id].joined_members)
         try:
             return {user_id: Member(membership=Membership.JOIN,
@@ -237,6 +242,7 @@ class EventMethods(BaseClientAPI):
             "limit": str(limit) if limit else None,
             "filter_json": filter_json,
         }
+        API_CALLS.labels(method="getMessages").inc()
         content = await self.api.request(Method.GET, Path.rooms[room_id].messages,
                                          query_params=query_params)
         try:
@@ -317,6 +323,7 @@ class EventMethods(BaseClientAPI):
             raise ValueError("Event type not given")
         url = Path.rooms[room_id].send[event_type][txn_id or self.api.get_txn_id()]
         content = content.serialize() if isinstance(content, Serializable) else content
+        API_CALLS.labels(method="sendMessageEvent").inc()
         resp = await self.api.request(Method.PUT, url, content, **kwargs)
         try:
             return resp["event_id"]
@@ -521,6 +528,7 @@ class EventMethods(BaseClientAPI):
             https://matrix.org/docs/spec/client_server/r0.5.0#put-matrix-client-r0-rooms-roomid-redact-eventid-txnid
         """
         url = Path.rooms[room_id].redact[event_id][self.api.get_txn_id()]
+        API_CALLS.labels(method="redact").inc()
         resp = await self.api.request(Method.PUT, url, content={"reason": reason}, **kwargs)
         try:
             return resp["event_id"]


### PR DESCRIPTION
This adds the following Prometheus metrics:

* `bridge_matrix_api_calls` Counter: Number of API calls made
* `bridge_matrix_api_calls_failed` Counter: Number of API calls which failed
* `matrix_request_seconds` Histogram: Duration in seconds of each API call

The names and types have been chosen to match those of https://github.com/matrix-org/matrix-appservice-bridge.

## Incomplete list of things which could be improved
- Cover other parts of the API, not just `events.py`.
- Write a wrapper function as the current code includes a lot of repetition.