### PR TITLE
Implement separate connection limits per user 

### DIFF
--- a/mautrix/appservice/api/appservice.py
+++ b/mautrix/appservice/api/appservice.py
@@ -73,7 +73,7 @@ class AppServiceAPI(HTTPAPI):
         self.state_store = state_store
         self.is_real_user = real_user
         self.real_user_content_key = real_user_content_key
-        self.create_child_session = create_child_session
+        self.create_child_session = create_child_session or (lambda: self.session)
 
         if not child:
             self.txn_id = 0

--- a/mautrix/bridge/bridge.py
+++ b/mautrix/bridge/bridge.py
@@ -116,6 +116,7 @@ class Bridge(Program, ABC):
                              domain=self.config["homeserver.domain"],
                              verify_ssl=self.config["homeserver.verify_ssl"],
                              connection_limit=self.config["homeserver.connection_limit"],
+                             connection_limit_per_user=self.config["homeserver.connection_limit_per_user"],
 
                              id=self.config["appservice.id"],
                              as_token=self.config["appservice.as_token"],

--- a/mautrix/bridge/config.py
+++ b/mautrix/bridge/config.py
@@ -57,6 +57,7 @@ class BaseBridgeConfig(BaseFileConfig, BaseValidatableConfig, ABC):
         copy("homeserver.verify_ssl")
         copy("homeserver.http_retry_count")
         copy("homeserver.connection_limit")
+        copy("homeserver.connection_limit_per_user")
         copy("homeserver.status_endpoint")
         copy("homeserver.message_send_checkpoint_endpoint")
 


### PR DESCRIPTION
Implements separate connection limits per user, to avoid scenarios where high traffic for a particular user can exhaust the connection pool and cause issues for other users.

This is configured by a new option `homeserver.connection_limit_per_user` (defaults to `10`).
It can be used alongside `homeserver.connection_limit` (from #64) which still applies to the appservice itself.

Example addition to a config file:
```yaml
homeserver:
    ...
    # Maximum number of simultaneous HTTP connections to the homeserver for a particular user.
    connection_limit_per_user: 5
```