### PR TITLE
message send tracking: add UNSUPPORTED and TIMEOUT statuses

### DIFF
--- a/mautrix/util/message_send_checkpoint.py
+++ b/mautrix/util/message_send_checkpoint.py
@@ -22,6 +22,8 @@ class MessageSendCheckpointStatus(SerializableEnum):
     SUCCESS = "SUCCESS"
     WILL_RETRY = "WILL_RETRY"
     PERM_FAILURE = "PERM_FAILURE"
+    UNSUPPORTED = "UNSUPPORTED"
+    TIMEOUT = "TIMEOUT"
 
 
 class MessageSendCheckpointReportedBy(SerializableEnum):


### PR DESCRIPTION
* UNSUPPORTED is for when a message is intentionally unsupported (for example, if the remote network does not support a feature)

* TIMEOUT is for when a message fails to send due to a timeout.