### PR TITLE
Stop database before exiting when starting fails

### DIFF
--- a/mautrix/bridge/bridge.py
+++ b/mautrix/bridge/bridge.py
@@ -182,6 +182,7 @@ class Bridge(Program, ABC):
                 "The as_token was not accepted. Is the registration file installed "
                 "in your homeserver correctly?"
             )
+            await self.stop_db()
             sys.exit(16)
         except MExclusive:
             self.log.critical(
@@ -189,6 +190,7 @@ class Bridge(Program, ABC):
                 "Are the homeserver domain and username template in the config "
                 "correct, and do they match the values in the registration?"
             )
+            await self.stop_db()
             sys.exit(16)
 
         await self.matrix.init_encryption()


### PR DESCRIPTION
In case the `as_token` or the `/register` request are not accepted, the application hangs indefinitely (when using SQLite). 
The reason for this is because [this thread](https://github.com/omnilib/aiosqlite/blob/main/aiosqlite/core.py#L84) in `aiosqlite` will never exit unless the connection is closed.
This can be solved by closing the database before exiting here.