### PR TITLE
Add 'download_media' to IntentAPI

### DIFF
--- a/mautrix/appservice/api/intent.py
+++ b/mautrix/appservice/api/intent.py
@@ -70,6 +70,7 @@ ENSURE_REGISTERED_METHODS = (
     ClientAPI.set_displayname,
     ClientAPI.set_avatar_url,
     ClientAPI.upload_media,
+    ClientAPI.download_media,
     ClientAPI.send_receipt,
     ClientAPI.set_fully_read_marker,
 )


### PR DESCRIPTION
Working on the problem with spurious 'avatar changes' in GChat rooms, the code will need to be able to download previously-uploaded avatar images from the Matrix media store (in order to compare contents to the 'new' image).