### PR TITLE
Add default `None` for `GlobalBridgeState.remote_states` field

### DIFF
--- a/mautrix/util/bridge_state.py
+++ b/mautrix/util/bridge_state.py
@@ -135,5 +135,5 @@ class BridgeState(SerializableAttrs):
 
 @dataclass(kw_only=True)
 class GlobalBridgeState(SerializableAttrs):
-    remote_states: Optional[Dict[str, BridgeState]] = field(json="remoteState")
+    remote_states: Optional[Dict[str, BridgeState]] = field(json="remoteState", default=None)
     bridge_state: BridgeState = field(json="bridgeState")


### PR DESCRIPTION
Fixes serialization of `GlobalBridgeState` with no remote states. The following errors without this change:

```py
from mautrix.util.bridge_state import BridgeState, BridgeStateEvent, GlobalBridgeState

GlobalBridgeState.deserialize(
    GlobalBridgeState(
        remote_states=None,
        bridge_state=BridgeState(state_event=BridgeStateEvent.UNCONFIGURED),
    ).serialize(),
)
```