### PR TITLE
always create group chat portal if is_direct==False

### DIFF
--- a/mautrix/bridge/matrix.py
+++ b/mautrix/bridge/matrix.py
@@ -298,7 +298,7 @@ class BaseMatrixHandler:
             return
         if create_evt.type == RoomType.SPACE:
             await self.handle_puppet_space_invite(room_id, puppet, invited_by, evt)
-        elif len(members) > 2:
+        elif len(members) > 2 or not evt.content.is_direct:
             await self.handle_puppet_group_invite(room_id, puppet, invited_by, evt, members)
         else:
             await self.handle_puppet_dm_invite(room_id, puppet, invited_by, evt)


### PR DESCRIPTION
Tested, works
I left the `len(members) > 2` check in because you most likely don't want to create a dm portal when inviting more than one user, even if `is_direct==True`