### PR TITLE
add support for outgoing knocks

### DIFF
--- a/mautrix/client/store_updater.py
+++ b/mautrix/client/store_updater.py
@@ -77,6 +77,17 @@ class StoreUpdatingAPI(ClientAPI):
         if not extra_content and self.state_store:
             await self.state_store.set_membership(room_id, self.mxid, Membership.LEAVE)
 
+    async def knock_room(
+        self,
+        room_id_or_alias: RoomID | RoomAlias,
+        reason: str | None = None,
+        servers: list[str] | None = None,
+    ) -> RoomID:
+        room_id = await super().knock_room(room_id_or_alias, reason, servers)
+        if room_id and self.state_store:
+            await self.state_store.set_membership(room_id, self.mxid, Membership.KNOCK)
+        return room_id
+
     async def invite_user(
         self,
         room_id: RoomID,


### PR DESCRIPTION
I hope this works, I don't yet have code to test it with.
I'm not sure whether
- the server list should be optional (I assumed so, because it also is on join_room)
- there should be any retries (like for join_room)
- there would be any extra_content