### PR TITLE
MSC3870: allow async media uploads to go to server-specified URL

### DIFF
--- a/mautrix/types/__init__.py
+++ b/mautrix/types/__init__.py
@@ -138,7 +138,14 @@ from .event import (
 )
 from .filter import EventFilter, Filter, RoomEventFilter, RoomFilter, StateFilter
 from .matrixuri import IdentifierType, MatrixURI, MatrixURIError, URIAction
-from .media import MediaRepoConfig, MXOpenGraph, OpenGraphAudio, OpenGraphImage, OpenGraphVideo
+from .media import (
+    MediaCreateResponse,
+    MediaRepoConfig,
+    MXOpenGraph,
+    OpenGraphAudio,
+    OpenGraphImage,
+    OpenGraphVideo,
+)
 from .misc import (
     BatchSendResponse,
     DeviceLists,
@@ -342,6 +349,7 @@ __all__ = [
     "OpenGraphAudio",
     "OpenGraphImage",
     "OpenGraphVideo",
+    "MediaCreateResponse",
     "BatchSendResponse",
     "DeviceLists",
     "DeviceOTKCount",

--- a/mautrix/types/media.py
+++ b/mautrix/types/media.py
@@ -3,6 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from typing import Optional
+
 from attr import dataclass
 
 from .primitive import ContentURI
@@ -59,3 +61,14 @@ class MXOpenGraph(SerializableAttrs):
     image: OpenGraphImage = field(default=None, flatten=True)
     video: OpenGraphVideo = field(default=None, flatten=True)
     audio: OpenGraphAudio = field(default=None, flatten=True)
+
+
+@dataclass
+class MediaCreateResponse(SerializableAttrs):
+    """
+    Matrix media create response including MSC3870
+    """
+
+    content_uri: ContentURI
+    unused_expired_at: Optional[int] = None
+    upload_url: Optional[str] = None


### PR DESCRIPTION
[MSC3870](https://github.com/Fizzadar/matrix-spec-proposals/blob/media-async-upload-url/proposals/3870-media-async-upload-url.md) extends the async media uploads spec to allow the server to specify a URL to send the media to.