### PR TITLE
`_fix_prev_content`: Handle events with `unsigned = None`

### DIFF
--- a/mautrix/appservice/as_handler.py
+++ b/mautrix/appservice/as_handler.py
@@ -199,10 +199,10 @@ class AppServiceServerMixin:
     def _fix_prev_content(raw_event: JSON) -> None:
         try:
             raw_event["unsigned"]["prev_content"]
-        except KeyError:
+        except (KeyError, TypeError):
             try:
                 raw_event.setdefault("unsigned", {})["prev_content"] = raw_event["prev_content"]
-            except KeyError:
+            except (KeyError, TypeError):
                 pass
 
     async def handle_transaction(

--- a/mautrix/appservice/as_handler.py
+++ b/mautrix/appservice/as_handler.py
@@ -197,13 +197,9 @@ class AppServiceServerMixin:
 
     @staticmethod
     def _fix_prev_content(raw_event: JSON) -> None:
-        try:
-            raw_event["unsigned"]["prev_content"]
-        except (KeyError, TypeError):
-            try:
-                raw_event.setdefault("unsigned", {})["prev_content"] = raw_event["prev_content"]
-            except (KeyError, TypeError):
-                pass
+        # MSC3442: `prev_content` should be under `unsigned`
+        if "prev_content" in raw_event:
+            raw_event.update({"unsigned": {"prev_content": raw_event["prev_content"]}})
 
     async def handle_transaction(
         self,


### PR DESCRIPTION
Getting a few of these errors in `mautrix-facebook.log`:

```
[2022-09-04 16:41:09,961] [ERROR@mau.as] Exception in transaction handler
Traceback (most recent call last):
  File "/opt/mautrix-facebook/.local/lib/python3.10/site-packages/mautrix/appservice/as_handler.py", line 179, in _http_handle_transaction
    output = await self.handle_transaction(
  File "/opt/mautrix-facebook/.local/lib/python3.10/site-packages/mautrix/appservice/as_handler.py", line 224, in handle_transaction
    self._fix_prev_content(raw_event)
  File "/opt/mautrix-facebook/.local/lib/python3.10/site-packages/mautrix/appservice/as_handler.py", line 198, in _fix_prev_content
    raw_event["unsigned"]["prev_content"]
TypeError: 'NoneType' object is not subscriptable
```

The `raw_event` is:
```json
{
    "content": {},
    "event_id": "$RiK5TJAl0PeI6K19kLN7cP_0j1CV_yv7mkfmcYwzOQw",
    "origin_server_ts": 1662391489373,
    "redacts": "$teMdHWflz0yAuQ8SeV0CsuPR1pBksS-aZno9it7w6xQ",
    "room_id': '!rZcNKiIFzkifgdAXmB:xn--sb-lka.org",
    "sender": "@fb_12341337:xn--sb-lka.org",
    "type": "m.room.redaction",
    "unsigned": None
}
```

Homeserver: conduit