### PR TITLE
Don't crash when stopping process during startup

### DIFF
--- a/mautrix/appservice/appservice.py
+++ b/mautrix/appservice/appservice.py
@@ -36,8 +36,8 @@ class AppService(AppServiceServerMixin):
     domain: str
     id: str
     verify_ssl: bool
-    tls_cert: str
-    tls_key: str
+    tls_cert: str | None
+    tls_key: str | None
     as_token: str
     hs_token: str
     bot_mxid: UserID
@@ -59,6 +59,7 @@ class AppService(AppServiceServerMixin):
     runner: web.AppRunner | None
 
     _http_session: aiohttp.ClientSession | None
+    _intent: IntentAPI | None
 
     def __init__(
         self,


### PR DESCRIPTION
It's possible for `AppService.stop` to be called before `AppService.start` finishes, namely when the process is SIGTERMed during a slow startup (like a hung DB schema upgrade).  If that happens, some variables used in `stop` may remain uninitialized, as they were assumed to have been initialized by `start`.

This PR adds some `None` checks & type hints to prevent that from being a problem.