### PR TITLE
Add probe_path and probe_bytes functions

### DIFF
--- a/mautrix/util/ffmpeg.py
+++ b/mautrix/util/ffmpeg.py
@@ -55,7 +55,6 @@ async def probe_path(
     input_file: os.PathLike[str] | str,
     logger: logging.Logger | None = None,
 ) -> Any:
-
     """
     Probes a media file on the disk using ffprobe.
 


### PR DESCRIPTION
Also add logging warns from ffmpeg and ffprobe, and handle the case when ffmpeg tries to encode a file with the same name (was happening when using convert_bytes with a file that's already .mp4)