### PR TITLE
Fix wait second handling in `proxy_with_retry`

### DIFF
--- a/mautrix/util/proxy.py
+++ b/mautrix/util/proxy.py
@@ -92,6 +92,7 @@ async def proxy_with_retry(
     max_retries: int = 10,
     min_wait_seconds: int = 0,
     max_wait_seconds: int = 60,
+    multiply_wait_seconds: int = 10,
     retryable_exceptions: tuple[Exception] = RETRYABLE_PROXY_EXCEPTIONS,
 ) -> T:
     errors = 0
@@ -103,7 +104,7 @@ async def proxy_with_retry(
             errors += 1
             if errors > max_retries:
                 raise
-            wait = errors * 10
+            wait = errors * multiply_wait_seconds
             wait = max(wait, min_wait_seconds)
             wait = min(wait, max_wait_seconds)
             logger.warning(

--- a/mautrix/util/proxy.py
+++ b/mautrix/util/proxy.py
@@ -90,7 +90,8 @@ async def proxy_with_retry(
     proxy_handler: ProxyHandler,
     on_proxy_change: Callable[[], Awaitable[None]],
     max_retries: int = 10,
-    min_wait_seconds: int = 60,
+    min_wait_seconds: int = 0,
+    max_wait_seconds: int = 60,
     retryable_exceptions: tuple[Exception] = RETRYABLE_PROXY_EXCEPTIONS,
 ) -> T:
     errors = 0
@@ -102,7 +103,9 @@ async def proxy_with_retry(
             errors += 1
             if errors > max_retries:
                 raise
-            wait = min(errors * 10, min_wait_seconds)
+            wait = errors * 10
+            wait = max(wait, min_wait_seconds)
+            wait = min(wait, max_wait_seconds)
             logger.warning(
                 "%s while trying to %s, retrying in %d seconds",
                 e.__class__.__name__,


### PR DESCRIPTION
🤦 

Adds new argument `max_wait_seconds` which actually was the broken behaviour of the previous `min_wait_seconds` which is now correctly handled.