### PR TITLE
Retry on `M_LIMIT_EXCEEDED`

### DIFF
--- a/mautrix/api.py
+++ b/mautrix/api.py
@@ -239,7 +239,7 @@ class HTTPAPI:
         )
         async with request as response:
             if response.status < 200 or response.status >= 300:
-                errcode = unstable_errcode = message = None
+                response_data = errcode = unstable_errcode = message = None
                 try:
                     response_data = await response.json()
                     errcode = response_data["errcode"]
@@ -250,6 +250,7 @@ class HTTPAPI:
                 raise make_request_error(
                     http_status=response.status,
                     text=await response.text(),
+                    data=response_data,
                     errcode=errcode,
                     message=message,
                     unstable_errcode=unstable_errcode,

--- a/mautrix/errors/request.py
+++ b/mautrix/errors/request.py
@@ -179,7 +179,9 @@ class MNotFound(MatrixStandardRequestError):
 
 @standard_error("M_LIMIT_EXCEEDED")
 class MLimitExceeded(MatrixStandardRequestError):
-    pass
+    def __init__(self, retry_after_ms: int | None = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.retry_after_ms: int | None = retry_after_ms
 
 
 @standard_error("M_UNKNOWN")


### PR DESCRIPTION
Closes #135

I adjusted `MatrixStandardRequestError` slightly. This is such that the error classes can store specific keys from the error response, like `retry_after_ms` in this PR.