### PR TITLE
Write temporary config file to system-wide temp dir

### DIFF
--- a/mautrix/util/config/file.py
+++ b/mautrix/util/config/file.py
@@ -50,7 +50,7 @@ class BaseFileConfig(BaseConfig, ABC):
     def save(self) -> None:
         try:
             tf = tempfile.NamedTemporaryFile(
-                mode="w", delete=False, suffix=".yaml", dir=os.path.dirname(self.path)
+                mode="w", delete=False, suffix=".yaml"
             )
         except OSError as e:
             log.warning(f"Failed to create tempfile to write updated config to disk: {e}")


### PR DESCRIPTION
I just spent an hour debugging why mautrix-telegram does not start on my NixOS system. Essentially, I was led on the wrong path by the first message that mautrix-telegram wrote to the journal:
```
Failed to create tempfile to write updated config to disk: [Errno 30] Read-only file system: '/nix/store/tmp_7ui8d3p.yaml'
```
This is because the config file is in `/nix/store` which is a read-only directory.
So it would be nice if the tempfile was written to `/tmp` for example.