### PR TITLE
fix typo: seconds -> milliseconds

### DIFF
--- a/mautrix/client/api/modules/misc.py
+++ b/mautrix/client/api/modules/misc.py
@@ -50,7 +50,7 @@ class MiscModuleMethods(BaseClientAPI):
 
         Args:
             room_id: The ID of the room in which the user is typing.
-            timeout: The length of time in seconds to mark this user as typing.
+            timeout: The length of time in milliseconds to mark this user as typing.
         """
         if timeout > 0:
             content = {"typing": True, "timeout": timeout}


### PR DESCRIPTION
For `set_typing`, the documentation says the `timeout` is in seconds, but the Matrix API docs say it is in milliseconds. Since the code does not do any conversion between seconds to milliseconds, it uses milliseconds, so I am updating the docstring to be correct.