### PR TITLE
Fix field name as per name in JSON response

### DIFF
--- a/mautrix/types/misc.py
+++ b/mautrix/types/misc.py
@@ -87,7 +87,7 @@ class PublicRoomInfo(SerializableAttrs):
     num_joined_members: int
 
     world_readable: bool
-    guests_can_join: bool
+    guest_can_join: bool
 
     name: str = None
     topic: str = None


### PR DESCRIPTION
This PR fixes the field name as per JSON response defined in [Matrix spec](https://spec.matrix.org/v1.8/client-server-api/#get_matrixclientv3publicrooms).

Currently this causes an error when JSON response is deserialised into `PublicRoomInfo` type and changing the field name fixes it.