### PR TITLE
metrics: add option `metrics.addr` for ipv6 support

### DIFF
--- a/mautrix/util/program.py
+++ b/mautrix/util/program.py
@@ -188,6 +188,7 @@ class Program:
         try:
             enabled = self.config["metrics.enabled"]
             listen_port = self.config["metrics.listen_port"]
+            addr = self.config.get("metrics.addr", "0.0.0.0")
         except KeyError:
             return
         if not enabled:
@@ -197,7 +198,7 @@ class Program:
                 "Metrics are enabled in config, but prometheus_client is not installed"
             )
             return
-        prometheus.start_http_server(listen_port)
+        prometheus.start_http_server(listen_port, addr=addr)
 
     def _run(self) -> None:
         signal.signal(signal.SIGINT, signal.default_int_handler)


### PR DESCRIPTION
`prometheus_client` supports IPv6 addresses for a while now[1]. This isn't used here however because the default 0.0.0.0 is used. Added an option `metrics.addr` that makes this configurable.

Tested with mautrix-telegram.

[1] https://github.com/prometheus/client_python/commit/39d2360322262947adae1908d0972fba12ff8ed1