### PR TITLE
Check login flows only if MSC4190 is not enabled

### DIFF
--- a/mautrix/bridge/e2ee.py
+++ b/mautrix/bridge/e2ee.py
@@ -247,12 +247,13 @@ class EncryptionManager:
         return decrypted
 
     async def start(self) -> None:
-        flows = await self.client.get_login_flows()
-        if not self.msc4190 and not flows.supports_type(LoginType.APPSERVICE):
-            self.log.critical(
-                "Encryption enabled in config, but homeserver does not support appservice login"
-            )
-            sys.exit(30)
+        if not self.msc4190:
+            flows = await self.client.get_login_flows()
+            if not flows.supports_type(LoginType.APPSERVICE):
+                self.log.critical(
+                    "Encryption enabled in config, but homeserver does not support appservice login"
+                )
+                sys.exit(30)
         self.log.debug("Logging in with bridge bot user")
         if self.crypto_db:
             try:


### PR DESCRIPTION
Currently, the homeserver login flows are checked even if MSC4190 is enabled. However, the `flows` variable is unused when MSC4190 is enabled.

This is an unnecessary network call, and also e.g. requires a reverse proxy soley for this purpose if bridges would otherwise directly connect to a homeserver that is delegating OIDC authentication.

Closes #177.

# Testing, linting, etc
- This change didn't have the test suite run, since locally my CMake version differs, so the olm package build fails locally, etc.
- I ran black and the pre-commit hooks from the Github actions.
- This bridge was tested on my homeserver, using my [custom build of `mautrix-googlechat`](https://github.com/meson800/googlechat) that uses `mautrix-python` from this commit with MSC4190 support. Docker container build [here](https://github.com/meson800/googlechat/pkgs/container/googlechat). Messages flow bidirectionally, double puppeting works, etc.