### PR TITLE
Fix login API called when MSC4190 enabled

### DIFF
--- a/mautrix/bridge/e2ee.py
+++ b/mautrix/bridge/e2ee.py
@@ -247,12 +247,13 @@ class EncryptionManager:
         return decrypted
 
     async def start(self) -> None:
-        flows = await self.client.get_login_flows()
-        if not self.msc4190 and not flows.supports_type(LoginType.APPSERVICE):
-            self.log.critical(
-                "Encryption enabled in config, but homeserver does not support appservice login"
-            )
-            sys.exit(30)
+        if not self.msc4190:
+            flows = await self.client.get_login_flows()
+            if not flows.supports_type(LoginType.APPSERVICE):
+                self.log.critical(
+                    "Encryption enabled in config, but homeserver does not support appservice login"
+                )
+                sys.exit(30)
         self.log.debug("Logging in with bridge bot user")
         if self.crypto_db:
             try:


### PR DESCRIPTION
Neither the GET nor POST variants of the Synapse `/login` API should be called when support for MSC4190 is enabled: https://areweoidcyet.com/

Fixes: mautrix/telegram#1020

----

I tested this by cloning the Telegram bridge locally and using my forked branch instead of the normal Mautrix library. After doing that I was able to once again use the local (non-public) address for my Synapse server and it correctly used the MSC4190 code instead of the `/login` endpoint. I was able to interact with Telegram normally from both the TG and Matrix sides.