### PR TITLE
Changed JoinRestrictionType to inherit from ExtensibleEnum

### DIFF
--- a/mautrix/types/event/state.py
+++ b/mautrix/types/event/state.py
@@ -9,7 +9,7 @@ from attr import dataclass
 import attr
 
 from ..primitive import JSON, ContentURI, EventID, RoomAlias, RoomID, UserID
-from ..util import Obj, SerializableAttrs, SerializableEnum, deserializer, field
+from ..util import Obj, SerializableAttrs, SerializableEnum, ExtensibleEnum, deserializer, field
 from .base import BaseRoomEvent, BaseUnsigned
 from .encrypted import EncryptionAlgorithm
 from .type import EventType, RoomType
@@ -168,7 +168,7 @@ class JoinRule(SerializableEnum):
     KNOCK_RESTRICTED = "knock_restricted"
 
 
-class JoinRestrictionType(SerializableEnum):
+class JoinRestrictionType(ExtensibleEnum):
     ROOM_MEMBERSHIP = "m.room_membership"
 
 


### PR DESCRIPTION
Fixes the crash I encountered while processing all events in the matrix #ping:maunium.net:

```
Traceback (most recent call last):
  File "/home/user/dev/ping_room_reader/.venv/lib/python3.14/site-packages/mautrix/types/util/serializable.py", line 101, in deserialize
    return cls(raw)
  File "/usr/lib/python3.14/enum.py", line 708, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.14/enum.py", line 1193, in __new__
    raise ve_exc
ValueError: 'fi.mau.spam_checker' is not a valid JoinRestrictionType
```

<!-- Make sure you read the contributing guidelines first:
https://docs.mau.fi/bridges/general/contributing.html -->
